### PR TITLE
Matrixロゴの使用を削除

### DIFF
--- a/src/components/views/auth/VectorAuthFooter.tsx
+++ b/src/components/views/auth/VectorAuthFooter.tsx
@@ -39,9 +39,6 @@ const VectorAuthFooter = (): ReactElement => {
     return (
         <footer className="mx_AuthFooter" role="contentinfo">
             {authFooterLinks}
-            <a href="https://matrix.org" target="_blank" rel="noreferrer noopener">
-                {_t("powered_by_matrix")}
-            </a>
         </footer>
     );
 };

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -33,7 +33,7 @@
     },
     "privacy_policy": "Privacy Policy",
     "powered_by_matrix": "Powered by Matrix",
-    "powered_by_matrix_with_logo": "Decentralised, encrypted chat &amp; collaboration powered by $matrixLogo",
+    "powered_by_matrix_with_logo": "Decentralised, encrypted chat &amp; collaboration",
     "unknown_device": "Unknown device",
     "use_brand_on_mobile": "Use %(brand)s on mobile",
     "web_default_device_name": "%(appName)s: %(browserName)s on %(osName)s",

--- a/src/i18n/strings/ja.json
+++ b/src/i18n/strings/ja.json
@@ -31,7 +31,7 @@
         "title": "サポートされていないブラウザー"
     },
     "privacy_policy": "プライバシーポリシー",
-    "powered_by_matrix_with_logo": "$matrixLogo による、分散型で暗号化された会話とコラボレーション",
+    "powered_by_matrix_with_logo": "分散型で暗号化された会話とコラボレーション",
     "unknown_device": "不明な端末",
     "use_brand_on_mobile": "携帯端末で%(brand)sを使用できます",
     "web_default_device_name": "%(appName)s： %(osName)sの%(browserName)s",


### PR DESCRIPTION
Apache 2.0ライセンスの商標に関する記載に配慮し、Matrixのロゴを削除